### PR TITLE
feat(resources): Add confirmation dialog before deleting a resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -656,7 +656,7 @@ This project uses **SQLite** with **DBUp** for database migrations. SQLite is a 
 
 2. **Restore dependencies**
    ```bash
-   dotnet restore
+   dotnet restore Freetool.sln
    ```
 
 3. **Install frontend dependencies**

--- a/www/src/__tests__/ResourcesView.test.tsx
+++ b/www/src/__tests__/ResourcesView.test.tsx
@@ -1,0 +1,149 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as api from "@/api/api";
+import ResourcesView from "@/features/space/components/ResourcesView";
+
+vi.mock("@/api/api");
+vi.mock("@/hooks/usePermissions", () => ({
+  useHasPermission: () => true,
+  useSpacePermissions: () => ({
+    permissions: {},
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+    can: () => true,
+  }),
+}));
+
+const mockResource = {
+  id: "res-1",
+  name: "My API",
+  description: "A test resource",
+  resourceKind: "http",
+  baseUrl: "https://api.example.com",
+  urlParameters: [],
+  headers: [],
+  body: [],
+  databaseConfig: {
+    databaseName: "",
+    host: "",
+    port: "",
+    engine: "postgres",
+    authScheme: "username_password",
+    username: "",
+    password: "",
+    useSsl: false,
+    enableSshTunnel: false,
+    connectionOptions: [],
+  },
+};
+
+function renderWithProviders(ui: React.ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>
+  );
+}
+
+describe("ResourcesView — delete confirmation dialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(api.getResources).mockResolvedValue({
+      data: { items: [mockResource], totalCount: 1 },
+    });
+    vi.mocked(api.getApps).mockResolvedValue({
+      data: { items: [], totalCount: 0 },
+    });
+    vi.mocked(api.deleteResource).mockResolvedValue({});
+  });
+
+  it("shows the confirmation dialog when trash is clicked", async () => {
+    renderWithProviders(<ResourcesView spaceId="space-1" />);
+
+    await waitFor(() => screen.getByText("My API"));
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Delete resource" })
+    );
+
+    expect(screen.getByText("Delete resource?")).toBeInTheDocument();
+    expect(
+      screen.getByText("This action cannot be undone.")
+    ).toBeInTheDocument();
+  });
+
+  it("does not delete when Cancel is clicked", async () => {
+    renderWithProviders(<ResourcesView spaceId="space-1" />);
+
+    await waitFor(() => screen.getByText("My API"));
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Delete resource" })
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(api.deleteResource).not.toHaveBeenCalled();
+    expect(screen.queryByText("Delete resource?")).not.toBeInTheDocument();
+  });
+
+  it("calls deleteResource when Delete is confirmed", async () => {
+    renderWithProviders(<ResourcesView spaceId="space-1" />);
+
+    await waitFor(() => screen.getByText("My API"));
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Delete resource" })
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Delete" }));
+
+    await waitFor(() => {
+      expect(api.deleteResource).toHaveBeenCalledWith("res-1");
+    });
+  });
+
+  it("closes the dialog when Escape is pressed", async () => {
+    renderWithProviders(<ResourcesView spaceId="space-1" />);
+
+    await waitFor(() => screen.getByText("My API"));
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Delete resource" })
+    );
+    expect(screen.getByText("Delete resource?")).toBeInTheDocument();
+
+    await userEvent.keyboard("{Escape}");
+
+    await waitFor(() =>
+      expect(screen.queryByText("Delete resource?")).not.toBeInTheDocument()
+    );
+    expect(api.deleteResource).not.toHaveBeenCalled();
+  });
+
+  it("shows Deleting... while delete is in flight", async () => {
+    let resolveDelete!: () => void;
+    vi.mocked(api.deleteResource).mockReturnValue(
+      new Promise((resolve) => {
+        resolveDelete = () => resolve({});
+      })
+    );
+
+    renderWithProviders(<ResourcesView spaceId="space-1" />);
+
+    await waitFor(() => screen.getByText("My API"));
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Delete resource" })
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Delete" }));
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Deleting..." })).toBeDisabled()
+    );
+
+    resolveDelete();
+  });
+});

--- a/www/src/features/space/components/ResourcesView.tsx
+++ b/www/src/features/space/components/ResourcesView.tsx
@@ -605,6 +605,7 @@ export default function ResourcesView({
                                 variant="ghost"
                                 size="icon"
                                 className="h-8 w-8"
+                                aria-label="Delete resource"
                                 onClick={() =>
                                   setConfirmDeleteResourceId(resource.id)
                                 }

--- a/www/src/features/space/components/ResourcesView.tsx
+++ b/www/src/features/space/components/ResourcesView.tsx
@@ -110,6 +110,9 @@ export default function ResourcesView({
   const [deletingResourceId, setDeletingResourceId] = useState<string | null>(
     null
   );
+  const [confirmDeleteResourceId, setConfirmDeleteResourceId] = useState<
+    string | null
+  >(null);
 
   // Pagination
   const { currentPage, pageSize, skip, totalPages, goToPage, setTotalCount } =
@@ -603,7 +606,7 @@ export default function ResourcesView({
                                 size="icon"
                                 className="h-8 w-8"
                                 onClick={() =>
-                                  handleDeleteResource(resource.id)
+                                  setConfirmDeleteResourceId(resource.id)
                                 }
                                 disabled={
                                   !canDeleteResource(resource.id) ||
@@ -658,6 +661,42 @@ export default function ResourcesView({
           />
         </>
       )}
+
+      <Dialog
+        open={!!confirmDeleteResourceId}
+        onOpenChange={() => setConfirmDeleteResourceId(null)}
+      >
+        <DialogContent className="max-w-sm">
+          <DialogHeader>
+            <DialogTitle>Delete resource?</DialogTitle>
+          </DialogHeader>
+          <p className="text-sm text-muted-foreground">
+            This action cannot be undone.
+          </p>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setConfirmDeleteResourceId(null)}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              disabled={deletingResourceId === confirmDeleteResourceId}
+              onClick={async () => {
+                if (confirmDeleteResourceId) {
+                  await handleDeleteResource(confirmDeleteResourceId);
+                  setConfirmDeleteResourceId(null);
+                }
+              }}
+            >
+              {deletingResourceId === confirmDeleteResourceId
+                ? "Deleting..."
+                : "Delete"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       <Dialog open={!!editingResource} onOpenChange={() => handleCloseEdit()}>
         <DialogContent className="max-w-3xl max-h-[80vh] overflow-hidden flex flex-col">

--- a/www/vite.config.ts
+++ b/www/vite.config.ts
@@ -11,43 +11,43 @@ export default defineConfig(({ mode }) => ({
     proxy: {
       // Only proxy API routes, not static assets
       "/app": {
-        target: process.env.VITE_API_URL || "http://localhost:5002",
+        target: process.env.VITE_API_URL || "http://localhost:5001",
         changeOrigin: true,
       },
       "/audit": {
-        target: process.env.VITE_API_URL || "http://localhost:5002",
+        target: process.env.VITE_API_URL || "http://localhost:5001",
         changeOrigin: true,
       },
       "/dev": {
-        target: process.env.VITE_API_URL || "http://localhost:5002",
+        target: process.env.VITE_API_URL || "http://localhost:5001",
         changeOrigin: true,
       },
       "/dashboard": {
-        target: process.env.VITE_API_URL || "http://localhost:5002",
+        target: process.env.VITE_API_URL || "http://localhost:5001",
         changeOrigin: true,
       },
       "/folder": {
-        target: process.env.VITE_API_URL || "http://localhost:5002",
+        target: process.env.VITE_API_URL || "http://localhost:5001",
         changeOrigin: true,
       },
       "/resource": {
-        target: process.env.VITE_API_URL || "http://localhost:5002",
+        target: process.env.VITE_API_URL || "http://localhost:5001",
         changeOrigin: true,
       },
       "/space": {
-        target: process.env.VITE_API_URL || "http://localhost:5002",
+        target: process.env.VITE_API_URL || "http://localhost:5001",
         changeOrigin: true,
       },
       "/trash": {
-        target: process.env.VITE_API_URL || "http://localhost:5002",
+        target: process.env.VITE_API_URL || "http://localhost:5001",
         changeOrigin: true,
       },
       "/user": {
-        target: process.env.VITE_API_URL || "http://localhost:5002",
+        target: process.env.VITE_API_URL || "http://localhost:5001",
         changeOrigin: true,
       },
       "/admin": {
-        target: process.env.VITE_API_URL || "http://localhost:5002",
+        target: process.env.VITE_API_URL || "http://localhost:5001",
         changeOrigin: true,
       },
     },

--- a/www/vite.config.ts
+++ b/www/vite.config.ts
@@ -11,43 +11,43 @@ export default defineConfig(({ mode }) => ({
     proxy: {
       // Only proxy API routes, not static assets
       "/app": {
-        target: process.env.VITE_API_URL || "http://localhost:5001",
+        target: process.env.VITE_API_URL || "http://localhost:5002",
         changeOrigin: true,
       },
       "/audit": {
-        target: process.env.VITE_API_URL || "http://localhost:5001",
+        target: process.env.VITE_API_URL || "http://localhost:5002",
         changeOrigin: true,
       },
       "/dev": {
-        target: process.env.VITE_API_URL || "http://localhost:5001",
+        target: process.env.VITE_API_URL || "http://localhost:5002",
         changeOrigin: true,
       },
       "/dashboard": {
-        target: process.env.VITE_API_URL || "http://localhost:5001",
+        target: process.env.VITE_API_URL || "http://localhost:5002",
         changeOrigin: true,
       },
       "/folder": {
-        target: process.env.VITE_API_URL || "http://localhost:5001",
+        target: process.env.VITE_API_URL || "http://localhost:5002",
         changeOrigin: true,
       },
       "/resource": {
-        target: process.env.VITE_API_URL || "http://localhost:5001",
+        target: process.env.VITE_API_URL || "http://localhost:5002",
         changeOrigin: true,
       },
       "/space": {
-        target: process.env.VITE_API_URL || "http://localhost:5001",
+        target: process.env.VITE_API_URL || "http://localhost:5002",
         changeOrigin: true,
       },
       "/trash": {
-        target: process.env.VITE_API_URL || "http://localhost:5001",
+        target: process.env.VITE_API_URL || "http://localhost:5002",
         changeOrigin: true,
       },
       "/user": {
-        target: process.env.VITE_API_URL || "http://localhost:5001",
+        target: process.env.VITE_API_URL || "http://localhost:5002",
         changeOrigin: true,
       },
       "/admin": {
-        target: process.env.VITE_API_URL || "http://localhost:5001",
+        target: process.env.VITE_API_URL || "http://localhost:5002",
         changeOrigin: true,
       },
     },


### PR DESCRIPTION
## Summary

- Added a confirmation dialog that appears when clicking the trash icon on a resource card
- Delete only proceeds after the user confirms — prevents accidental deletions
- Shows \"Deleting...\" state while the request is in flight

## Fixes

- README restore command updated to `dotnet restore Freetool.sln`

## Test plan

- [x] Click trash icon on a resource → confirmation dialog appears
- [x] Click Cancel → dialog closes, resource is not deleted
- [x] Click Delete → resource is deleted, dialog closes
- [x] Delete button shows \"Deleting...\" and is disabled while in flight
- [x] Resources that are in use still show the disabled trash icon with tooltip